### PR TITLE
patch for multiple addresses with unquoted display parts

### DIFF
--- a/lib/tmail/parser.rb
+++ b/lib/tmail/parser.rb
@@ -56,7 +56,7 @@ module_eval <<'..end lib/tmail/parser.y modeval..id2dd1c7d21d', 'lib/tmail/parse
     # around the display name when the display name contains a '@'
     # like 'mikel@me.com <mikel@me.com>'
     # Just quotes it to: '"mikel@me.com" <mikel@me.com>'
-    when str =~ /\A([^"].+@.+[^"])\s(<.*?>)\Z/
+    when str =~ /\A([^"][^<]+@[^>]+[^"])\s(<.*?>)\Z/
       return "\"#{$1}\" #{$2}"
     # This handles cases where 'Mikel A. <mikel@me.com>' which is a trailing
     # full stop before the address section.  Just quotes it to

--- a/test/test_header.rb
+++ b/test/test_header.rb
@@ -154,6 +154,17 @@ class AddressHeaderTester < Test::Unit::TestCase
           :routes => [],
           :spec => 'hoge@example.jp'}]
     }
+    
+    validate_case 'Mikel <mikel@me.org>, another Mikel <mikel@you.org>',
+        false, 
+        'Mikel <mikel@me.org>, another Mikel <mikel@you.org>',
+        [],
+    [{  :phrase => 'Mikel', 
+        :routes => [], 
+        :spec   => 'mikel@me.org' },
+     {  :phrase => 'another Mikel', 
+        :routes => [], 
+        :spec   => 'mikel@you.org' }]
   end
 end
 


### PR DESCRIPTION
Reduce scope of special case for matching '@' in display name - was matching in case of multiple addresses with unquoted display names. Not a great way to patch but have added test case in case anyone can do a better job.
